### PR TITLE
Add agent language selection modal to code generation

### DIFF
--- a/packages/webapp/src/main/components/application-bar/menues/generate-code-menu.tsx
+++ b/packages/webapp/src/main/components/application-bar/menues/generate-code-menu.tsx
@@ -9,6 +9,10 @@ import { BACKEND_URL } from '../../../constant';
 import { UMLDiagramType } from '@besser/wme';
 
 export const GenerateCodeMenu: React.FC = () => {
+  // Modal for spoken language selection for agent diagrams
+  const [showAgentLanguageModal, setShowAgentLanguageModal] = useState(false);
+  const [selectedAgentLanguages, setSelectedAgentLanguages] = useState<string[]>([]);
+  const [dropdownLanguage, setDropdownLanguage] = useState<string>('none');
   const [showDjangoConfig, setShowDjangoConfig] = useState(false);
   const [showSqlConfig, setShowSqlConfig] = useState(false);
   const [showSqlAlchemyConfig, setShowSqlAlchemyConfig] = useState(false);
@@ -32,7 +36,7 @@ export const GenerateCodeMenu: React.FC = () => {
                             (BACKEND_URL ?? '').includes('localhost') || 
                             (BACKEND_URL ?? '').includes('127.0.0.1');
 
-  const handleGenerateCode = async (generatorType: string) => {
+  const handleGenerateCode = async (generatorType: string, languages?: string[]) => {
     if (!editor || !diagram?.title) {
       toast.error('No diagram available to generate code from');
       return;
@@ -59,7 +63,15 @@ export const GenerateCodeMenu: React.FC = () => {
     }
 
     try {
-      await generateCode(editor, generatorType, diagram.title);
+      if (generatorType === 'agent' && languages) {
+        if (Array.isArray(languages)) {
+          await generateCode(editor, generatorType, diagram.title, { languages: languages });
+        } else {
+          await generateCode(editor, generatorType, diagram.title);
+        }
+      } else {
+        await generateCode(editor, generatorType, diagram.title);
+      }
     } catch (error) {
       console.error('Error in code generation:', error);
       toast.error('Code generation failed. Check console for details.');
@@ -179,77 +191,146 @@ export const GenerateCodeMenu: React.FC = () => {
   return (
     <>
       <NavDropdown title="Generate" className="pt-0 pb-0">
-      {isAgentDiagram ? (
-        // Agent Diagram: Only show agent generation option
-        <Dropdown.Item onClick={() => handleGenerateCode('agent')}>BESSER Agent</Dropdown.Item>
-      ) : currentDiagramType === UMLDiagramType.ClassDiagram ? (
-        // Class Diagram: Show all other options
-        <>
-          {/* Web Dropdown */}
-          <Dropdown drop="end">
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              split
-              className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
-            >
-              <span className="flex-grow-1">Web</span>
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              <Dropdown.Item onClick={() => handleGenerateCode('django')}>Django Project</Dropdown.Item>
-              <Dropdown.Item onClick={() => handleGenerateCode('backend')}>Full Backend</Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
+        {isAgentDiagram ? (
+          // Agent Diagram: Show agent generation option, but open language modal
+          <Dropdown.Item onClick={() => setShowAgentLanguageModal(true)}>BESSER Agent</Dropdown.Item>
+        ) : currentDiagramType === UMLDiagramType.ClassDiagram ? (
+          // ...existing code...
+          <>
+            {/* Web Dropdown */}
+            <Dropdown drop="end">
+              <Dropdown.Toggle
+                id="dropdown-basic"
+                split
+                className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
+              >
+                <span className="flex-grow-1">Web</span>
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                <Dropdown.Item onClick={() => handleGenerateCode('django')}>Django Project</Dropdown.Item>
+                <Dropdown.Item onClick={() => handleGenerateCode('backend')}>Full Backend</Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
 
-          {/* Database Dropdown */}
-          <Dropdown drop="end">
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              split
-              className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
-            >
-              <span className="flex-grow-1">Database</span>
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              <Dropdown.Item onClick={() => handleGenerateCode('sql')}>SQL DDL</Dropdown.Item>
-              <Dropdown.Item onClick={() => handleGenerateCode('sqlalchemy')}>SQLAlchemy DDL</Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
+            {/* Database Dropdown */}
+            <Dropdown drop="end">
+              <Dropdown.Toggle
+                id="dropdown-basic"
+                split
+                className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
+              >
+                <span className="flex-grow-1">Database</span>
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                <Dropdown.Item onClick={() => handleGenerateCode('sql')}>SQL DDL</Dropdown.Item>
+                <Dropdown.Item onClick={() => handleGenerateCode('sqlalchemy')}>SQLAlchemy DDL</Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
 
-          {/* OOP Dropdown */}
-          <Dropdown drop="end">
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              split
-              className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
-            >
-              <span className="flex-grow-1">OOP</span>
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              <Dropdown.Item onClick={() => handleGenerateCode('python')}>Python Classes</Dropdown.Item>
-              <Dropdown.Item onClick={() => handleGenerateCode('java')}>Java Classes</Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
+            {/* OOP Dropdown */}
+            <Dropdown drop="end">
+              <Dropdown.Toggle
+                id="dropdown-basic"
+                split
+                className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
+              >
+                <span className="flex-grow-1">OOP</span>
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                <Dropdown.Item onClick={() => handleGenerateCode('python')}>Python Classes</Dropdown.Item>
+                <Dropdown.Item onClick={() => handleGenerateCode('java')}>Java Classes</Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
 
-          {/* Schema Dropdown */}
-          <Dropdown drop="end">
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              split
-              className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
-            >
-              <span className="flex-grow-1">Schema</span>
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              <Dropdown.Item onClick={() => handleGenerateCode('pydantic')}>Pydantic Models</Dropdown.Item>
-              <Dropdown.Item onClick={() => handleGenerateCode('jsonschema')}>JSON Schema</Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </>
-      ) : (
-        // Not yet available
-        <Dropdown.Item disabled>Not yet available</Dropdown.Item>
-      )}
-    </NavDropdown>
+            {/* Schema Dropdown */}
+            <Dropdown drop="end">
+              <Dropdown.Toggle
+                id="dropdown-basic"
+                split
+                className="bg-transparent w-100 text-start ps-3 d-flex align-items-center"
+              >
+                <span className="flex-grow-1">Schema</span>
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                <Dropdown.Item onClick={() => handleGenerateCode('pydantic')}>Pydantic Models</Dropdown.Item>
+                <Dropdown.Item onClick={() => handleGenerateCode('jsonschema')}>JSON Schema</Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
+          </>
+        ) : (
+          // Not yet available
+          <Dropdown.Item disabled>Not yet available</Dropdown.Item>
+        )}
+      </NavDropdown>
+
+      {/* Agent Language Selection Modal (dropdown + removable list) */}
+      <Modal show={showAgentLanguageModal} onHide={() => setShowAgentLanguageModal(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Select Agent Languages</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form>
+            <Form.Group className="mb-3">
+              <Form.Label>Add spoken language for agent translation</Form.Label>
+              <Form.Select
+                value={dropdownLanguage}
+                onChange={(e) => setDropdownLanguage(e.target.value)}
+              >
+                <option value="none">Select language...</option>
+                <option value="french">French</option>
+                <option value="german">German</option>
+                <option value="luxembourgish">Luxembourgish</option>
+                <option value="portuguese">Portuguese</option>
+                <option value="spanish">Spanish</option>
+              </Form.Select>
+              <Button
+                className="mt-2"
+                variant="primary"
+                disabled={dropdownLanguage === 'none' || selectedAgentLanguages.includes(dropdownLanguage)}
+                onClick={() => {
+                  if (dropdownLanguage !== 'none' && !selectedAgentLanguages.includes(dropdownLanguage)) {
+                    setSelectedAgentLanguages([...selectedAgentLanguages, dropdownLanguage]);
+                    setDropdownLanguage('none');
+                  }
+                }}
+              >
+                Add Language
+              </Button>
+              <Form.Text className="text-muted d-block mt-2">
+                The agent will be translated to all selected spoken languages.
+              </Form.Text>
+            </Form.Group>
+            {/* List of selected languages with remove option */}
+            {selectedAgentLanguages.length > 0 && (
+              <div className="mb-3">
+                <strong>Selected Languages:</strong>
+                <ul className="list-unstyled mt-2">
+                  {selectedAgentLanguages.map(lang => (
+                    <li key={lang} className="d-flex align-items-center mb-1">
+                      <span className="me-2">{lang.charAt(0).toUpperCase() + lang.slice(1)}</span>
+                      <Button
+                        variant="outline-danger"
+                        size="sm"
+                        onClick={() => setSelectedAgentLanguages(selectedAgentLanguages.filter(l => l !== lang))}
+                      >
+                        Remove
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowAgentLanguageModal(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => { setShowAgentLanguageModal(false); handleGenerateCode('agent', selectedAgentLanguages); }}>
+            Generate
+          </Button>
+        </Modal.Footer>
+      </Modal>
 
       {/* Django Configuration Modal */}
       <Modal show={showDjangoConfig} onHide={() => setShowDjangoConfig(false)}>


### PR DESCRIPTION
Introduces a modal for selecting spoken languages when generating code for agent diagrams. The selected languages are passed to the code generation handler, allowing agents to be translated into multiple languages. Updates UI logic to trigger the modal for agent diagrams and refactors the code generation handler to support language options.